### PR TITLE
Update codecov.io usage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
       run: make testci
 
     - name: report code coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
-        file: ./coverage.out
+        files: ./coverage.out
       if: ${{ matrix.go-version == '1.17' }}


### PR DESCRIPTION
v1 is deprecated:
https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1