### PR TITLE
Use generics for a typesafe API

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,8 +11,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.39.0
+          version: v1.55.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,24 +14,24 @@ jobs:
     strategy:
       matrix:
         go-version:
-        - '1.17'
-        - '1.16'
-        - '1.15'
+        - '1.21'
+        - '1.20'
+        - '1.19'
 
     steps:
     - name: setup
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{matrix.go-version}}
 
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: test
       run: make testci
 
     - name: report code coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         files: ./coverage.out
-      if: ${{ matrix.go-version == '1.17' }}
+      if: ${{ matrix.go-version == '1.21' }}

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ COVERAGE_PATH ?= coverage.out
 COVERAGE_ARGS ?= -covermode=atomic -coverprofile=$(COVERAGE_PATH)
 TEST_ARGS     ?= -race $(COVERAGE_ARGS)
 
-# Tool dependencies
-TOOL_BIN_DIR     ?= $(shell go env GOPATH)/bin
-TOOL_GOLINT      := $(TOOL_BIN_DIR)/golint
-TOOL_STATICCHECK := $(TOOL_BIN_DIR)/staticcheck
+# 3rd party tools
+LINT        := go run github.com/mgechev/revive@v1.3.4
+REFLEX      := go run github.com/cespare/reflex@v0.3.1
+STATICCHECK := go run honnef.co/go/tools/cmd/staticcheck@2023.1.3
 
 test:
 	go test $(TEST_ARGS) ./...
@@ -23,19 +23,13 @@ testcover: testci
 	go tool cover -html=$(COVERAGE_PATH)
 .PHONY: testcover
 
-lint: $(TOOL_GOLINT) $(TOOL_STATICCHECK)
+lint:
 	test -z "$$(gofmt -d -s -e .)" || (echo "Error: gofmt failed"; gofmt -d -s -e . ; exit 1)
 	go vet ./...
-	$(TOOL_GOLINT) -set_exit_status ./...
-	$(TOOL_STATICCHECK) ./...
+	$(LINT) -set_exit_status ./...
+	$(STATICCHECK) ./...
 .PHONY: lint
 
 clean:
 	rm -rf $(COVERAGE_PATH)
 .PHONY: clean
-
-$(TOOL_GOLINT):
-	cd /tmp && go get -u golang.org/x/lint/golint
-
-$(TOOL_STATICCHECK):
-	cd /tmp && go get -u honnef.co/go/tools/cmd/staticcheck

--- a/example_test.go
+++ b/example_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/mccutchen/fillcache"
@@ -20,13 +21,16 @@ func Example() {
 		wg        sync.WaitGroup
 	)
 
-	// Create our cache with a simple cache filling function that just waits a
-	// constant amount of time before returning a value
-	cache := fillcache.New(func(ctx context.Context, key string) (interface{}, error) {
+	// A simple cache filling function that just waits a constant amount of
+	// time before returning a value
+	filler := func(ctx context.Context, key string) (int, error) {
 		<-time.After(fillDelay)
 		fmt.Printf("computed value for key %q: %d\n", key, val)
 		return val, nil
-	})
+	}
+
+	// Create our cache with the simple cache filling function above.
+	cache := fillcache.New(filler, nil)
 
 	// Launch a thundering herd of 10 concurrent cache gets
 	for i := 0; i < 10; i++ {
@@ -34,7 +38,7 @@ func Example() {
 		go func(i int) {
 			defer wg.Done()
 			result, _ := cache.Get(context.Background(), key)
-			fmt.Printf("got value for key %q: %d\n", key, result.(int))
+			fmt.Printf("got value for key %q: %d\n", key, result)
 		}(i)
 	}
 
@@ -54,30 +58,43 @@ func Example() {
 	// got value for key "foo": 42
 }
 
-// ExampleTTL shows how to set a TTL for cache entries
-func ExampleTTL() {
+// ExampleNew shows how to customize a cache instance with configuration
+// options.
+func ExampleConfig() {
 	var (
 		key       = "foo"
 		val       = 42
 		fillDelay = 250 * time.Millisecond
+		calls     = &atomic.Int64{}
 	)
 
-	// A simple cache filling function that just waits a constant amount of
-	// time before returning a value
-	filler := func(ctx context.Context, key string) (interface{}, error) {
+	// A fallible cache filling function that waits a constant amount of time
+	// before returning a value or an error.
+	filler := func(ctx context.Context, key string) (int, error) {
 		<-time.After(fillDelay)
+		if calls.Add(1)%2 == 0 {
+			fmt.Printf("error filling cache for key %q, should serve stale\n", key)
+			return 0, fmt.Errorf("error")
+		}
 		fmt.Printf("computed value for key %q: %d\n", key, val)
 		return val, nil
 	}
 
-	// Create our cache with a 50ms TTL
-	cache := fillcache.New(filler, fillcache.TTL(50*time.Millisecond))
+	// Create a cache configured with a 50ms TTL and configured to serve stale
+	// values in the face of a fill error.
+	cache := fillcache.New(filler, &fillcache.Config{
+		// Cache entries will be re-filled after 50ms
+		TTL: 50 * time.Millisecond,
+		// If an error occurs during re-fill but we have a previously cached
+		// value, it will be returned instead of the error.
+		ServeStale: true,
+	})
 
 	// Fetch the key every 20ms for 100ms to ensure that the value is recomputed
 	// after the 50ms TTL
 	for i := 0; i < 5; i++ {
 		result, _ := cache.Get(context.Background(), key)
-		fmt.Printf("got value for key %q: %d\n", key, result.(int))
+		fmt.Printf("got value for key %q: %d\n", key, result)
 		<-time.After(20 * time.Millisecond)
 	}
 
@@ -86,7 +103,8 @@ func ExampleTTL() {
 	// got value for key "foo": 42
 	// got value for key "foo": 42
 	// got value for key "foo": 42
-	// computed value for key "foo": 42
+	// error filling cache for key "foo", should serve stale
 	// got value for key "foo": 42
+	// computed value for key "foo": 42
 	// got value for key "foo": 42
 }

--- a/fillcache_test.go
+++ b/fillcache_test.go
@@ -68,8 +68,10 @@ func (t *testFiller) filler(ctx context.Context, key string) (interface{}, error
 }
 
 func TestGetFillsCache(t *testing.T) {
+	t.Parallel()
+
 	f := newSimpleFiller("foo", 1, 10*time.Millisecond)
-	c := fillcache.New(f.filler)
+	c := fillcache.New(f.filler, nil)
 	ctx := context.Background()
 
 	// first get should compute the expected result
@@ -102,8 +104,10 @@ func TestGetFillsCache(t *testing.T) {
 }
 
 func TestParallelGetFillsCacheOnce(t *testing.T) {
+	t.Parallel()
+
 	f := newSimpleFiller("foo", 1, 200*time.Millisecond)
-	c := fillcache.New(f.filler)
+	c := fillcache.New(f.filler, nil)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
@@ -128,8 +132,10 @@ func TestParallelGetFillsCacheOnce(t *testing.T) {
 }
 
 func TestGetRespectsContexts(t *testing.T) {
+	t.Parallel()
+
 	f := newSimpleFiller("foo", 1, 50*time.Millisecond)
-	c := fillcache.New(f.filler)
+	c := fillcache.New(f.filler, nil)
 
 	baseCtx := context.Background()
 
@@ -165,11 +171,13 @@ func TestGetRespectsContexts(t *testing.T) {
 }
 
 func TestGetDoesNotCacheOnError(t *testing.T) {
+	t.Parallel()
+
 	results := map[string]result{
 		"foo": {err: errors.New("error")},
 	}
 	f := newTestFiller(results, 10*time.Millisecond)
-	c := fillcache.New(f.filler)
+	c := fillcache.New(f.filler, nil)
 
 	_, err := c.Get(context.Background(), "foo")
 	if err == nil || err.Error() != "error" {
@@ -181,11 +189,13 @@ func TestGetDoesNotCacheOnError(t *testing.T) {
 }
 
 func TestGetPropagatesErrorsToAllCallers(t *testing.T) {
+	t.Parallel()
+
 	results := map[string]result{
 		"foo": {err: errors.New("error")},
 	}
 	f := newTestFiller(results, 100*time.Millisecond)
-	c := fillcache.New(f.filler)
+	c := fillcache.New(f.filler, nil)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
@@ -206,8 +216,10 @@ func TestGetPropagatesErrorsToAllCallers(t *testing.T) {
 }
 
 func TestUpdateRespectsContexts(t *testing.T) {
+	t.Parallel()
+
 	f := newSimpleFiller("foo", 1, 50*time.Millisecond)
-	c := fillcache.New(f.filler)
+	c := fillcache.New(f.filler, nil)
 
 	baseCtx := context.Background()
 
@@ -232,11 +244,13 @@ func TestUpdateRespectsContexts(t *testing.T) {
 }
 
 func TestUpdateDoesNotCacheOnError(t *testing.T) {
+	t.Parallel()
+
 	results := map[string]result{
 		"foo": {err: errors.New("error")},
 	}
 	f := newTestFiller(results, 10*time.Millisecond)
-	c := fillcache.New(f.filler)
+	c := fillcache.New(f.filler, nil)
 
 	_, err := c.Update(context.Background(), "foo")
 	if err == nil || err.Error() != "error" {
@@ -248,8 +262,10 @@ func TestUpdateDoesNotCacheOnError(t *testing.T) {
 }
 
 func TestParallelUpdateFillsCacheOnce(t *testing.T) {
+	t.Parallel()
+
 	f := newSimpleFiller("foo", 1, 200*time.Millisecond)
-	c := fillcache.New(f.filler)
+	c := fillcache.New(f.filler, nil)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
@@ -270,8 +286,10 @@ func TestParallelUpdateFillsCacheOnce(t *testing.T) {
 }
 
 func TestParallelGetsAndUpdatesFillCacheOnce(t *testing.T) {
+	t.Parallel()
+
 	f := newSimpleFiller("foo", 1, 200*time.Millisecond)
-	c := fillcache.New(f.filler)
+	c := fillcache.New(f.filler, nil)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
@@ -314,8 +332,10 @@ func TestWaiterRespectsContexts(t *testing.T) {
 	//
 	// The cache fill should succeed, because there was no timeout applied to
 	// the context that triggered the fill.
+	t.Parallel()
+
 	f := newSimpleFiller("foo", 1, 200*time.Millisecond)
-	c := fillcache.New(f.filler)
+	c := fillcache.New(f.filler, nil)
 
 	var wg sync.WaitGroup
 
@@ -370,8 +390,10 @@ func TestFillSuccessDeterminedByFirstContext(t *testing.T) {
 	// will be waiting on the same cache fill and so will also fail.
 	//
 	// Afterwards, the cache will still be empty.
+	t.Parallel()
+
 	f := newSimpleFiller("foo", 1, 200*time.Millisecond)
-	c := fillcache.New(f.filler)
+	c := fillcache.New(f.filler, nil)
 
 	var wg sync.WaitGroup
 
@@ -408,11 +430,13 @@ func TestFillSuccessDeterminedByFirstContext(t *testing.T) {
 }
 
 func TestExpiration(t *testing.T) {
+	t.Parallel()
+
 	key := "foo"
 	val := 1
 	ttl := 25 * time.Millisecond
 	f := newSimpleFiller(key, val, time.Duration(0))
-	c := fillcache.New(f.filler, fillcache.TTL(ttl))
+	c := fillcache.New(f.filler, &fillcache.Config{TTL: ttl})
 
 	for i := 0; i < 15; i++ {
 		result, err := c.Get(context.Background(), key)
@@ -431,6 +455,8 @@ func TestExpiration(t *testing.T) {
 }
 
 func TestServeStale(t *testing.T) {
+	t.Parallel()
+
 	key := "foo"
 	val := int64(0)
 	ttl := 10 * time.Millisecond
@@ -447,7 +473,7 @@ func TestServeStale(t *testing.T) {
 		}
 	}
 
-	c := fillcache.New(filler, fillcache.TTL(ttl), fillcache.ServeStale(true))
+	c := fillcache.New(filler, &fillcache.Config{TTL: ttl, ServeStale: true})
 
 	// First fill succeeds
 	result, err := c.Get(context.Background(), key)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mccutchen/fillcache
 
-go 1.12
+go 1.18


### PR DESCRIPTION
Here we update the fillcache API to use generics for better type safety.  This bumps the minimum go version to 1.18.

We also make a breaking API change, dropping the "functional options" pattern for initializing a cache instance in favor of an explicit config struct.  I've become more convinced over time that the explicitness of config structs (or explicit arguments) is preferable over the kinda hidden magic of the functional options pattern.  Plus, making functional options work in a clean with generics was beyond my meager skills and I didn't want to spend any more time fighting the compiler!